### PR TITLE
Lift ViewModel out of Screens and up to Navigation layer, update dependencies, & add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Pokedex
-Pokedex Android app I wrote in order to learn how to use Jetpack Compose.
+Pokedex Android app I'm writing to learn Jetpack Compose.
 
 # TODO:
-- Unit & Instrumentation Tests
+- Instrumentation Tests
 - Cacheing
 - Obfuscation
 - Move hardcoded strings to strings.xml for Localization

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
@@ -51,7 +51,7 @@ android {
 dependencies {
 
     implementation 'io.coil-kt:coil-compose:2.4.0'
-    implementation 'androidx.navigation:navigation-compose:2.5.3'
+    implementation 'androidx.navigation:navigation-compose:2.6.0'
     implementation 'androidx.lifecycle:lifecycle-runtime-compose:2.6.1'
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.moshi:moshi:1.14.0'
@@ -69,11 +69,22 @@ dependencies {
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
     implementation 'androidx.core:core-ktx:1.10.1'
+
+    // Local unit tests
+    testImplementation 'androidx.test:core:1.5.0'
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'androidx.arch.core:core-testing:2.2.0'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.1'
+    testImplementation 'com.google.truth:truth:1.1.3'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.1'
+    testImplementation 'io.mockk:mockk:1.10.5'
+
+
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation platform('androidx.compose:compose-bom:2022.10.00')
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+
     debugImplementation 'androidx.compose.ui:ui-tooling'
     debugImplementation 'androidx.compose.ui:ui-test-manifest'
 }

--- a/app/src/main/java/com/ryancphil/pokedex/data/PokedexRepository.kt
+++ b/app/src/main/java/com/ryancphil/pokedex/data/PokedexRepository.kt
@@ -1,42 +1,11 @@
 package com.ryancphil.pokedex.data
 
-import android.util.Log
 import com.ryancphil.pokedex.data.model.PokemonListResponse
 import com.ryancphil.pokedex.data.model.PokemonResponse
-import javax.inject.Inject
 
-class PokedexRepository
-@Inject
-constructor(
-    private val service: PokedexService
-) {
+interface PokedexRepository {
 
-    suspend fun fetchPokemonList(
-        offset: Int,
-        limit: Int
-    ): PokemonListResponse? {
-        return try {
-            val list = service.getPokemonList(
-                offset,
-                limit
-            )
-            Log.d("PokedexRepository", "Successfully fetched Pokemon List!")
-            return list
-        } catch (e: Exception) {
-            Log.e("PokedexRepository", "Failed to fetch Pokemon List!")
-            null
-        }
-    }
+    suspend fun fetchPokemonList(offset: Int, limit: Int): PokemonListResponse?
 
-    suspend fun fetchPokemonDetails(id: Int): PokemonResponse? {
-        return try {
-            val pokemon = service.getPokemonById(id)
-            Log.d("PokedexRepository", "Pokemon Details: $pokemon")
-            pokemon
-        } catch (e: Exception) {
-            Log.e("PokedexRepository", "Failed to fetch Pokemon details for: $id!")
-            Log.e("PokedexRepository", "Exception: $e")
-            null
-        }
-    }
+    suspend fun fetchPokemonDetails(pokemonId: Int): PokemonResponse?
 }

--- a/app/src/main/java/com/ryancphil/pokedex/data/PokedexRepositoryImpl.kt
+++ b/app/src/main/java/com/ryancphil/pokedex/data/PokedexRepositoryImpl.kt
@@ -1,0 +1,42 @@
+package com.ryancphil.pokedex.data
+
+import android.util.Log
+import com.ryancphil.pokedex.data.model.PokemonListResponse
+import com.ryancphil.pokedex.data.model.PokemonResponse
+import javax.inject.Inject
+
+class PokedexRepositoryImpl
+@Inject
+constructor(
+    private val service: PokedexService
+): PokedexRepository {
+
+    override suspend fun fetchPokemonList(
+        offset: Int,
+        limit: Int
+    ): PokemonListResponse? {
+        return try {
+            val list = service.getPokemonList(
+                offset,
+                limit
+            )
+            Log.d("PokedexRepository", "Successfully fetched Pokemon List!")
+            return list
+        } catch (e: Exception) {
+            Log.e("PokedexRepository", "Failed to fetch Pokemon List!")
+            null
+        }
+    }
+
+    override suspend fun fetchPokemonDetails(pokemonId: Int): PokemonResponse? {
+        return try {
+            val pokemon = service.getPokemonById(pokemonId)
+            Log.d("PokedexRepository", "Pokemon Details: $pokemon")
+            pokemon
+        } catch (e: Exception) {
+            Log.e("PokedexRepository", "Failed to fetch Pokemon details for: $pokemonId!")
+            Log.e("PokedexRepository", "Exception: $e")
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/ryancphil/pokedex/detail/PokemonDetailState.kt
+++ b/app/src/main/java/com/ryancphil/pokedex/detail/PokemonDetailState.kt
@@ -1,6 +1,6 @@
 package com.ryancphil.pokedex.detail
 
-data class PokemonDetailViewState(
+data class PokemonDetailState(
     val isLoading: Boolean = true,
     val error: String? = null,
     val name: String = "",

--- a/app/src/main/java/com/ryancphil/pokedex/detail/PokemonDetailUseCase.kt
+++ b/app/src/main/java/com/ryancphil/pokedex/detail/PokemonDetailUseCase.kt
@@ -1,6 +1,7 @@
 package com.ryancphil.pokedex.detail
 
 import com.ryancphil.pokedex.data.PokedexRepository
+import com.ryancphil.pokedex.data.PokedexRepositoryImpl
 import com.ryancphil.pokedex.data.model.StatResponse
 import com.ryancphil.pokedex.data.model.TypeResponse
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/com/ryancphil/pokedex/detail/PokemonDetailUseCase.kt
+++ b/app/src/main/java/com/ryancphil/pokedex/detail/PokemonDetailUseCase.kt
@@ -1,7 +1,6 @@
 package com.ryancphil.pokedex.detail
 
 import com.ryancphil.pokedex.data.PokedexRepository
-import com.ryancphil.pokedex.data.model.PokemonResponse
 import com.ryancphil.pokedex.data.model.StatResponse
 import com.ryancphil.pokedex.data.model.TypeResponse
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,8 +18,8 @@ constructor(
     private val pokedexRepository: PokedexRepository
 ) {
 
-    private val _pokemon: MutableStateFlow<PokemonDetailViewState> = MutableStateFlow(PokemonDetailViewState())
-    val pokemon: StateFlow<PokemonDetailViewState> = _pokemon.asStateFlow()
+    private val _pokemon: MutableStateFlow<PokemonDetailState> = MutableStateFlow(PokemonDetailState())
+    val pokemon: StateFlow<PokemonDetailState> = _pokemon.asStateFlow()
 
     suspend fun getPokemonDetailViewState(id: Int) {
         val detailResponse = pokedexRepository.fetchPokemonDetails(id)

--- a/app/src/main/java/com/ryancphil/pokedex/detail/composable/ScreenPokemonDetails.kt
+++ b/app/src/main/java/com/ryancphil/pokedex/detail/composable/ScreenPokemonDetails.kt
@@ -19,8 +19,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -31,40 +29,33 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
-import com.ryancphil.pokedex.MainViewModel
-import com.ryancphil.pokedex.detail.PokemonDetailViewState
+import com.ryancphil.pokedex.detail.PokemonDetailState
 import com.ryancphil.pokedex.rememberWindowInfo
 
 @Composable
 fun ScreenPokemonDetails(
-    pokemonId: Int,
-    viewModel: MainViewModel
+    pokemonDetailState: PokemonDetailState
 ) {
-    LaunchedEffect(key1 = "detail", block = {
-        viewModel.fetchPokemonDetails(pokemonId)
-    })
-    val pokemonDetailViewState by viewModel.pokemon.collectAsStateWithLifecycle()
     Box(
         modifier = Modifier
             .fillMaxSize(),
         contentAlignment = Alignment.Center
     ) {
-        if (pokemonDetailViewState.isLoading) {
+        if (pokemonDetailState.isLoading) {
             CircularProgressIndicator(
                 modifier = Modifier
                     .height(50.dp)
                     .width(50.dp)
                     .align(Alignment.Center)
             )
-        } else if (pokemonDetailViewState.error != null) {
-            Error(error = pokemonDetailViewState.error)
+        } else if (pokemonDetailState.error != null) {
+            Error(error = pokemonDetailState.error)
         } else {
             val windowInfo = rememberWindowInfo()
-            when(windowInfo.orientation) {
-                ORIENTATION_PORTRAIT -> Portrait(state = pokemonDetailViewState)
-                else -> Landscape(state = pokemonDetailViewState)
+            when (windowInfo.orientation) {
+                ORIENTATION_PORTRAIT -> Portrait(state = pokemonDetailState)
+                else -> Landscape(state = pokemonDetailState)
             }
         }
     }
@@ -88,7 +79,7 @@ fun Error(
 
 @Composable
 fun Portrait(
-    state: PokemonDetailViewState
+    state: PokemonDetailState
 ) {
     Column(
         modifier = Modifier
@@ -126,7 +117,7 @@ fun Portrait(
 
 @Composable
 fun Landscape(
-    state: PokemonDetailViewState
+    state: PokemonDetailState
 ) {
     Row(
         modifier = Modifier

--- a/app/src/main/java/com/ryancphil/pokedex/di/AppModule.kt
+++ b/app/src/main/java/com/ryancphil/pokedex/di/AppModule.kt
@@ -32,5 +32,4 @@ object AppModule {
     @Provides
     fun provideApiService(retrofit: Retrofit): PokedexService =
         retrofit.create(PokedexService::class.java)
-
 }

--- a/app/src/main/java/com/ryancphil/pokedex/di/PokedexModule.kt
+++ b/app/src/main/java/com/ryancphil/pokedex/di/PokedexModule.kt
@@ -1,0 +1,16 @@
+package com.ryancphil.pokedex.di
+
+import com.ryancphil.pokedex.data.PokedexRepository
+import com.ryancphil.pokedex.data.PokedexRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class PokedexModule {
+
+    @Binds
+    abstract fun bindPokedexRepository(pokedexRepositoryImpl: PokedexRepositoryImpl): PokedexRepository
+}

--- a/app/src/main/java/com/ryancphil/pokedex/list/PokemonListState.kt
+++ b/app/src/main/java/com/ryancphil/pokedex/list/PokemonListState.kt
@@ -1,6 +1,6 @@
 package com.ryancphil.pokedex.list
 
-data class PokemonListViewState(
+data class PokemonListState(
     val isLoading: Boolean = false,
     val names: List<String> = emptyList(),
     val error: String? = null,

--- a/app/src/main/java/com/ryancphil/pokedex/list/PokemonListUseCase.kt
+++ b/app/src/main/java/com/ryancphil/pokedex/list/PokemonListUseCase.kt
@@ -1,7 +1,7 @@
 package com.ryancphil.pokedex.list
 
 import com.ryancphil.pokedex.capitalizeAll
-import com.ryancphil.pokedex.data.PokedexRepository
+import com.ryancphil.pokedex.data.PokedexRepositoryImpl
 import com.ryancphil.pokedex.data.model.PokemonListResponse
 import com.ryancphil.pokedex.data.paging.DefaultPaginator
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,7 +14,7 @@ private const val pageSize = 20
 class PokemonListUseCase
 @Inject
 constructor(
-    private val pokedexRepository: PokedexRepository
+    private val pokedexRepository: PokedexRepositoryImpl
 ) {
 
     private val _pokemonList: MutableStateFlow<PokemonListState> =

--- a/app/src/main/java/com/ryancphil/pokedex/list/PokemonListUseCase.kt
+++ b/app/src/main/java/com/ryancphil/pokedex/list/PokemonListUseCase.kt
@@ -17,9 +17,9 @@ constructor(
     private val pokedexRepository: PokedexRepository
 ) {
 
-    private val _pokemonList: MutableStateFlow<PokemonListViewState> =
-        MutableStateFlow(PokemonListViewState())
-    val pokemonList: StateFlow<PokemonListViewState> = _pokemonList.asStateFlow()
+    private val _pokemonList: MutableStateFlow<PokemonListState> =
+        MutableStateFlow(PokemonListState())
+    val pokemonList: StateFlow<PokemonListState> = _pokemonList.asStateFlow()
 
     val paginator = DefaultPaginator(
         0,

--- a/app/src/main/java/com/ryancphil/pokedex/list/composable/ScreenPokemonList.kt
+++ b/app/src/main/java/com/ryancphil/pokedex/list/composable/ScreenPokemonList.kt
@@ -1,6 +1,5 @@
 package com.ryancphil.pokedex.list.composable
 
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -18,38 +17,31 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.ryancphil.pokedex.MainViewModel
-import com.ryancphil.pokedex.navigation.Screen
-import kotlinx.coroutines.launch
+import com.ryancphil.pokedex.list.PokemonListState
 
 @Composable
 fun ScreenPokemonList(
-    viewModel: MainViewModel,
-    openDetail: (String) -> Unit
+    pokemonListState: PokemonListState,
+    loadPage: () -> Unit,
+    onClick: (Int) -> Unit
 ) {
-    val scope = rememberCoroutineScope()
-    val pokemonListViewState by viewModel.pokemonList.collectAsStateWithLifecycle()
     LazyColumn {
         itemsIndexed(
-            items = pokemonListViewState.names
+            items = pokemonListState.names
         ) { index, pokemonName ->
-            if (index >= pokemonListViewState.names.size - 1 && !pokemonListViewState.endReached && !pokemonListViewState.isLoading) {
-                LaunchedEffect(key1 = "list", block = {
-                    viewModel.fetchPokemonList()
-                })
+            if (
+                index >= pokemonListState.names.size - 1 &&
+                !pokemonListState.endReached &&
+                !pokemonListState.isLoading
+            ) {
+                loadPage()
             }
             PokemonRowItem(name = pokemonName) {
                 val id = index + 1
-                val destination = Screen.ScreenPokemonDetails.withArgs(id.toString())
-                Log.d("ScreenPokemonList", "Destination: $destination")
-                openDetail(destination)
+                onClick(id)
             }
             Spacer(
                 modifier = Modifier
@@ -59,15 +51,13 @@ fun ScreenPokemonList(
             )
         }
         item {
-            if (pokemonListViewState.isLoading) {
+            if (pokemonListState.isLoading) {
                 LoadingIndicator()
-            } else if (pokemonListViewState.error != null) {
+            } else if (pokemonListState.error != null) {
                 ErrorRefreshItem(
-                    errorMessage = pokemonListViewState.error.toString(),
+                    errorMessage = pokemonListState.error.toString(),
                     onRefresh = {
-                        scope.launch {
-                            viewModel.fetchPokemonList()
-                        }
+                        loadPage()
                     }
                 )
             }

--- a/app/src/main/java/com/ryancphil/pokedex/navigation/Navigation.kt
+++ b/app/src/main/java/com/ryancphil/pokedex/navigation/Navigation.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -46,11 +47,18 @@ fun Navigation(
                 startDestination = Screen.ScreenPokemonList.route
             ) {
                 composable(route = Screen.ScreenPokemonList.route) {
+                    val pokemonListState by viewModel.pokemonList.collectAsStateWithLifecycle()
                     ScreenPokemonList(
-                        viewModel = viewModel
-                    ) { destination ->
-                        navController.navigate(destination)
-                    }
+                        pokemonListState = pokemonListState,
+                        loadPage = {
+                            viewModel.fetchPokemonList()
+                        },
+                        onClick = { pokemonId ->
+                            viewModel.fetchPokemonDetails(pokemonId)
+                            val destination = Screen.ScreenPokemonDetails.withArgs(pokemonId.toString())
+                            navController.navigate(destination)
+                        }
+                    )
                 }
                 composable(
                     route = Screen.ScreenPokemonDetails.route + "/{pokemonId}",
@@ -64,9 +72,9 @@ fun Navigation(
                     if (pokemonId == null) {
                         Log.e("Navigation", "Error: pokemonId cannot be null.")
                     } else {
+                        val pokemonDetailState by viewModel.pokemon.collectAsStateWithLifecycle()
                         ScreenPokemonDetails(
-                            pokemonId = pokemonId,
-                            viewModel = viewModel
+                            pokemonDetailState = pokemonDetailState
                         )
                     }
                 }

--- a/app/src/test/java/com/ryancphil/pokedex/PokemonDetailUseCaseTest.kt
+++ b/app/src/test/java/com/ryancphil/pokedex/PokemonDetailUseCaseTest.kt
@@ -1,0 +1,44 @@
+package com.ryancphil.pokedex
+
+import com.google.common.truth.Truth.assertThat
+import com.ryancphil.pokedex.data.repository.FakePokedexRepository
+import com.ryancphil.pokedex.detail.PokemonDetailUseCase
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+
+class PokemonDetailUseCaseTest {
+
+    private lateinit var fakePokedexRepository: FakePokedexRepository
+    private lateinit var pokemonDetailUseCase: PokemonDetailUseCase
+
+    @Before
+    fun setup() {
+        fakePokedexRepository = FakePokedexRepository()
+        pokemonDetailUseCase = PokemonDetailUseCase(fakePokedexRepository)
+    }
+
+    @Test
+    fun `loading state is true by default`() {
+        assertThat(pokemonDetailUseCase.pokemon.value.isLoading).isTrue()
+    }
+
+    @Test
+    fun `loading state is false after successful fetchPokemonDetails`() = runBlocking {
+        pokemonDetailUseCase.getPokemonDetailViewState(1)
+        assertThat(pokemonDetailUseCase.pokemon.value.isLoading).isFalse()
+    }
+
+    @Test
+    fun `error state contains message after failed fetchPokemonDetails`() = runBlocking {
+        pokemonDetailUseCase.getPokemonDetailViewState(-1)
+        assertThat(pokemonDetailUseCase.pokemon.value.error).isNotEmpty()
+    }
+
+
+    @Test
+    fun `fetchPokemonDetails sets state`() = runBlocking {
+        pokemonDetailUseCase.getPokemonDetailViewState(1)
+        assertThat(pokemonDetailUseCase.pokemon.value.name).isEqualTo("Bulbasaur")
+    }
+}

--- a/app/src/test/java/com/ryancphil/pokedex/data/repository/FakePokedexRepository.kt
+++ b/app/src/test/java/com/ryancphil/pokedex/data/repository/FakePokedexRepository.kt
@@ -1,0 +1,50 @@
+package com.ryancphil.pokedex.data.repository
+
+import com.ryancphil.pokedex.data.PokedexRepository
+import com.ryancphil.pokedex.data.model.NameAndUrlResponse
+import com.ryancphil.pokedex.data.model.PokemonListResponse
+import com.ryancphil.pokedex.data.model.PokemonResponse
+import com.ryancphil.pokedex.data.model.SpritesResponse
+
+class FakePokedexRepository: PokedexRepository {
+    override suspend fun fetchPokemonList(offset: Int, limit: Int): PokemonListResponse? {
+        return PokemonListResponse(
+            5,
+            "next_page",
+            "previous_page",
+            listOf(
+                NameAndUrlResponse(name = "", url = ""),
+                NameAndUrlResponse(name = "", url = ""),
+                NameAndUrlResponse(name = "", url = ""),
+                NameAndUrlResponse(name = "", url = ""),
+                NameAndUrlResponse(name = "", url = "")
+            )
+        )
+    }
+
+    override suspend fun fetchPokemonDetails(pokemonId: Int): PokemonResponse? {
+        if (pokemonId <= 0) {
+            return null
+        }
+        return PokemonResponse(
+            name = "Bulbasaur",
+            sprites = SpritesResponse(""),
+            abilities = emptyList(),
+            baseExperience = 50,
+            forms = emptyList(),
+            gameIndices = emptyList(),
+            height = 17,
+            heldItems = emptyList(),
+            id = 1,
+            isDefault = false,
+            locationAreaEncounters = null,
+            moves = emptyList(),
+            order = 1,
+            pastTypes = emptyList(),
+            species = null,
+            stats = emptyList(),
+            types = emptyList(),
+            weight = 100
+        )
+    }
+}


### PR DESCRIPTION
Lifting viewmodel preserves @Preview functionality for screens as well as reduces side-effects. 

Added some simple unit tests for `PokemonDetailUseCase`

Updated README